### PR TITLE
Update rule-empty-line-before rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -246,7 +246,8 @@ module.exports = {
     'property-case': 'lower',
     'rule-empty-line-before': [
       'always-multi-line', {
-        except: 'first-nested'
+        except: 'first-nested',
+        ignore: 'after-comment'
       }
     ],
     'unit-case': 'lower'


### PR DESCRIPTION
This PR updates `rule-empty-line-before` rule to ignore empty line after comment.

Example:
- Bad
```js
/* comment */

.foo {
  bar: biz;
}
```

- Correct

```js
/* comment */
.foo {
  bar: biz;
}
```