### PR TITLE
Update value-keyword-case rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -261,6 +261,8 @@ module.exports = {
     'selector-pseudo-element-case': 'lower',
     'selector-pseudo-element-colon-notation': 'double',
     'unit-case': 'lower',
-    'value-keyword-case': 'lower'
+    'value-keyword-case': ['lower', {
+      ignoreKeywords: ['dummyValue']
+    }]
   }
 };

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -93,6 +93,7 @@ const UnitCase = styled.div`
 // `value-keyword-case`.
 const ValueKeywordCase = styled.div`
   display: block;
+  width: ${units(1)};
 `;
 
 // `at-rule-no-unknown`.


### PR DESCRIPTION
This PR updates _value-keyword-case_ rule to ignore interpolations.
ex:
```js
const ValueKeywordCase = styled.div`
  display: block;
  width: ${units(1)};

  ${media.min('md')`
    display: inline-block;
  `}
`;
```

