### PR TITLE
Add support for nullish coalescing operator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,24 @@ module.exports = {
     'stylelint-high-performance-animation',
     'stylelint-order'
   ],
-  processors: ['stylelint-processor-styled-components'],
+  processors: [
+    ['stylelint-processor-styled-components', {
+      parserPlugins: [
+        'jsx',
+        'objectRestSpread',
+        ['decorators', { decoratorsBeforeExport: true }],
+        'classProperties',
+        'exportExtensions',
+        'asyncGenerators',
+        'functionBind',
+        'functionSent',
+        'dynamicImport',
+        'optionalCatchBinding',
+        'optionalChaining',
+        'nullishCoalescingOperator'
+      ]
+    }]
+  ],
   rules: {
     'declaration-block-semicolon-newline-after': 'always',
     'declaration-block-semicolon-space-before': 'never',


### PR DESCRIPTION
This PR adds support for the [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator).

To add support for this, all the default parser plugins had to be added as well, as there is no way to add a single parser plugin. The defaults can be consulted [here](https://github.com/styled-components/stylelint-processor-styled-components#setup).