### PR TITLE
Add string-quotes rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,6 +283,7 @@ module.exports = {
     ],
     'selector-pseudo-element-case': 'lower',
     'selector-pseudo-element-colon-notation': 'double',
+    'string-quotes': 'single',
     'unit-case': 'lower',
     'value-keyword-case': ['lower', {
       ignoreKeywords: ['dummyValue']

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -197,7 +197,12 @@ const SelectorTypeNoUnknown = styled.div`
 
 // `string-no-newline`.
 const StringNoNewline = styled.div`
-  font-family: "Times New Roman", serif;
+  font-family: 'Times New Roman', serif;
+`;
+
+// `string-quotes`.
+const StringQuotes = styled.div`
+  content: '';
 `;
 
 // `unit-no-unknown`.

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -210,9 +210,14 @@ const SelectorTypeNoUnknown = styled.div`
 
 // `string-no-newline`.
 const StringNoNewline = styled.div`
-  font-family: "Times
+  font-family: 'Times
     New
-    Roman", serif;
+    Roman', serif;
+`;
+
+// `string-quotes`.
+const StringQuotes = styled.div`
+  content: "";
 `;
 
 // `unit-case`.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -76,6 +76,7 @@ describe('stylelint-config-seegno', () => {
           'selector-pseudo-element-no-unknown',
           'selector-type-no-unknown',
           'string-no-newline',
+          'string-quotes',
           'unit-case',
           'unit-no-unknown',
           'value-keyword-case',


### PR DESCRIPTION
This PR adds the `string-quotes` rule with the `single` option to enforce the usage of single quotes in CSS.

Closes https://github.com/seegno/stylelint-config-seegno/issues/37