### PR TITLE
Update lint-staged configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
     "lint-staged"
   ],
   "lint-staged": {
+    "(src|test)/**/*.js": [
+      "jest --findRelatedTests"
+    ],
     "**/*.js": [
       "eslint"
     ],
     "package.json": [
-      "sort-package-json",
-      "git add"
+      "sort-package-json"
     ]
   },
   "jest": {


### PR DESCRIPTION
This PR updates the `lint-staged` configuration so that tests are run before committing.

This also removes the unnecessary `git add` command still on the `lint-staged` configuration.